### PR TITLE
Correction for allow proper working of Begin()

### DIFF
--- a/VCNL4010.cpp
+++ b/VCNL4010.cpp
@@ -24,7 +24,7 @@ VCNL4010::~VCNL4010() {} // of class destructor                               //
 *******************************************************************************************************************/
 bool VCNL4010::begin( ) {                                                     // Start I2C Comms with device      //
   Wire.begin();                                                               // Start I2C as master device       //
-  if (readByte(VCNL4010_PRODUCT_ID_REG)!=VCNL4010_PRODUCT_VERSION)            // If the product doesn't match then//
+  if (readByteBegin(VCNL4010_PRODUCT_ID_REG)!=VCNL4010_PRODUCT_VERSION)       // If the product doesn't match then//
     return false;                                                             // return an error                  //
   setProximityHz(2);                                                          // Default 2Hz proximity rate       //
   setLEDmA(20);                                                               // Default 20mA IR LED power        //
@@ -36,6 +36,17 @@ bool VCNL4010::begin( ) {                                                     //
   writeByte(VCNL4010_COMMAND_REG,commandBuffer);                              // Start the measurement cycle      //
   return true;                                                                // return success                   //
 } // of method begin()                                                        //                                  //
+/*******************************************************************************************************************
+** Method readByteBegin reads 1 byte from the specified address, but not wait for a response. Used in begin()     **
+*******************************************************************************************************************/
+uint8_t VCNL4010::readByteBegin(const uint8_t addr) {                         //                                  //
+  Wire.beginTransmission(VCNL4010_ADDRESS);                                   // Address the I2C device           //
+  Wire.write(addr);                                                           // Send the register address to read//
+  _TransmissionStatus = Wire.endTransmission();                               // Close transmission               //
+  delayMicroseconds(VCNL4010_I2C_DELAY);                                      // delay required for sync          //
+  Wire.requestFrom(VCNL4010_ADDRESS, (uint8_t)1);                             // Request 1 byte of data           //
+  return Wire.read();                                                         // read and return it, also is empty//
+} // of method readByteBegin()                                                //                                  //
 /*******************************************************************************************************************
 ** Method readByte reads 1 byte from the specified address                                                        **
 *******************************************************************************************************************/

--- a/VCNL4010.h
+++ b/VCNL4010.h
@@ -79,6 +79,7 @@
       uint8_t  getInterrupt();                                                // Retrieve Interrupt bits          //
       void     clearInterrupt(const uint8_t intVal=0);                        // Clear Interrupt bits             //
     private:                                                                  // Private methods                  //
+      uint8_t  readByteBegin(const uint8_t addr);                             // Read from I2C to check sensor    //
       uint8_t  readByte(const uint8_t addr);                                  // Read 1 byte from address on I2C  //
       uint16_t readWord(const uint8_t addr);                                  // Read 2 bytes from address on I2C //
       void     writeByte(const uint8_t addr, const uint8_t data);             // Write 1 byte at address to I2C   //


### PR DESCRIPTION
Hi,

I made a little correction to allow the Begin function to fail and return false in case a sensor is not attached, instead of just freezing up waiting for a response because is never going to receive data from I2C if there is nothing to fetch. 

I hope you find useful this little fix for your library.

Great job :) 